### PR TITLE
Fix for n^th term notation

### DIFF
--- a/sequences/notation.tex
+++ b/sequences/notation.tex
@@ -85,10 +85,10 @@ Let's summarize the preceding discussion in the following definition.
   integers starting with an index $N$.
 
   The ``outputs'' of a sequence are the \defnword{terms} of the
-  sequence; the ``$n^{\nth}$ term'' is the real number that the
+  sequence; the ``$n^{th}$ term'' is the real number that the
   sequence associates to the natural number $n$, and is usually
   written $a_n$. \index{sequence!term} The $n$ in the phrase
-  ``$n^{\nth}$ term'' is called an
+  ``$n^{th}$ term'' is called an
   \defnword{index}\index{sequence!index}; the plural of index is
   either indices or indexes, depending on who you ask.  The first
   index $N$ is called the \defnword{initial


### PR DESCRIPTION
This should correct the n^th notation. It is currently displaying "n^\scriptsize th".
